### PR TITLE
Fix git repo paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,16 +10,16 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/jbovenschen/storybook-addon-a11y.git"
+    "url": "git+https://github.com/storybooks/storybook-addon-a11y.git"
   },
   "keywords": [
     "storybook"
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/jbovenschen/storybook-addon-a11y/issues"
+    "url": "https://github.com/storybooks/storybook-addon-a11y/issues"
   },
-  "homepage": "https://github.com/jbovenschen/storybook-addon-a11y#readme",
+  "homepage": "https://github.com/storybooks/storybook-addon-a11y#readme",
   "devDependencies": {
     "@storybook/react": "^3.0.0",
     "babel-cli": "^6.14.0",


### PR DESCRIPTION
After we moved the repo to storybooks org, paths were still pointing to my previous repo.