### PR TITLE
Get rid of extra span

### DIFF
--- a/src/components/WrapStory.js
+++ b/src/components/WrapStory.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { findDOMNode } from 'react-dom';
 import PropTypes from 'prop-types';
 import axe from 'axe-core';
 
@@ -11,20 +12,19 @@ class WrapStory extends Component {
 
   componentDidMount() {
     const { channel } = this.props;
+    const wrapper = findDOMNode(this);
 
-    axe.a11yCheck(this.wrapper, {}, (results) => {
-      channel.emit('addon:a11y:check', results);
-    });
+    if (wrapper !== null) {
+      axe.a11yCheck(wrapper, {}, (results) => {
+        channel.emit('addon:a11y:check', results);
+      });
+    }
   }
 
   render() {
     const { storyFn, context } = this.props;
 
-    return (<span
-        ref={ (container) => { this.wrapper = container; } }
-      >
-        {storyFn(context)}
-      </span>)
+    return storyFn(context);
   }
 }
 


### PR DESCRIPTION
This PR removes the wrapping span to keep the html structure of the story untouched. This allows us to integrate this awesome plugin into a existing storybook setup with storyshots snapshot testing.

Before this PR my test failed when this addon is included:
```
  ● Storyshots › Button › with text
    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    -<button
    -  className="red"
    -  onClick={[Function]}
    ->
    -  Hello Button
    -</button>
    +<span>
    +  <button
    +    className="red"
    +    onClick={[Function]}
    +  >
    +    Hello Button
    +  </button>
    +</span>
```